### PR TITLE
Added CSRF token form insertion to the add and edit jade templates.

### DIFF
--- a/views/jade/add.jade
+++ b/views/jade/add.jade
@@ -12,6 +12,8 @@ block body
       each field, key in fields
         +fieldWidget(key, field, data[key])
       div
+        input(type="hidden", name="_csrf", value=_csrf)
+      div
         button().btn.btn-success
           i.glyphicon.glyphicon-ok
           | &nbsp;Create

--- a/views/jade/edit.jade
+++ b/views/jade/edit.jade
@@ -14,6 +14,8 @@ block body
       each field, key in fields
         +fieldWidget(key, field, record[key])
       div
+        input(type="hidden", name="_csrf", value=_csrf)
+      div
         button().btn.btn-success
           i.glyphicon.glyphicon-ok
           | &nbsp;Save


### PR DESCRIPTION
I run CSRF validation on my site, and when I attempted to use the admin panel hook, adding and editing values would not work due to no csrf support.

I've added the like to the template files as invisible elements.  Should now work on CSRF enabled servers for those two pages.  I tested delete but it seems to work fine without it.  Unsure if there are other places that might require it.